### PR TITLE
fix: shebang for exec format and sync main with HEAD

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -56,7 +56,6 @@ jobs:
         cluster_name: '${{ vars.CLUSTER_NAME }}'
         project_id: '${{ vars.PROJECT_ID }}'
         namespace: '${{ vars.NAMESPACE }}'
-        expose: '${{ vars.EXPOSE }}'
 
     - name: 'get credentials'
       uses: 'google-github-actions/get-gke-credentials@v2'

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,2 @@
 * @google-github-actions/maintainers
+* @google-github-actions/deploy-gke-maintainers

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,3 +1,5 @@
+#!/bin/sh -l
+
 # Copyright 2024 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -11,8 +13,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
-#!/bin/sh -l
 
 gha_version="0.1.0"
 


### PR DESCRIPTION
This commit fixes shebang for exec format and syncs `main` with HEAD.

<!--
Thank you for proposing a pull request! Please note that SOME TESTS WILL
LIKELY FAIL due to how GitHub exposes secrets in Pull Requests from forks.
Someone from the team will review your Pull Request and respond.

Please describe your change and any implementation details below.
-->
