### PR TITLE
Add optional input `k8s_manifests`

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ jobs:
         project_id: 'my-project'
         namespace: 'my-namespace'
         expose: '8000'
+        k8s_manifests: 'configs'
     
     - name: 'get-deployments'
       shell: bash
@@ -65,3 +66,9 @@ jobs:
 - `expose` - (Optional) The port provided will be used to expose the deployed
    workload object (i.e., port and targetPort will be set to the value provided
    in this flag). If not provided, it will not be passed to the binary.
+
+- `k8s_manifests` - (Optional) Local or GCS path to configuration file or
+   directory of configuration files to use to create Kubernetes objects
+   (file or files in directory must end in ".yml" or ".yaml").
+   Prefix this value with "gs://" to indicate a GCS path.
+   If not provided, it will not be passed to the binary.

--- a/action.yml
+++ b/action.yml
@@ -55,6 +55,13 @@ inputs:
       If not provided, it will not be passed to the binary.
     required: false
 
+  k8s_manifests:
+    description: |-
+      Local or GCS path to configuration file or directory of configuration files to use to create Kubernetes objects (file or files in directory must end in ".yml" or ".yaml").
+      Prefix this value with "gs://" to indicate a GCS path.
+      If not provided, it will not be passed to the binary.
+    required: false
+
 branding:
   icon: 'lock'
   color: 'blue'

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -23,6 +23,7 @@ cluster_name="$4"
 project_id="$5"
 namespace="$6"
 expose_port="$7"
+k8s_manifests="$8"
 
 gke_deploy_command="gke-deploy run -i $image -a $app_name -l $location -c $cluster_name -p $project_id"
 
@@ -40,6 +41,11 @@ fi
 # Add expose port if the input is apparent.
 if [ -n "$expose_port" ]; then
   gke_deploy_command="$gke_deploy_command -x $expose_port"
+fi
+
+# Add k8s manifests file(s) if the input is apparent.
+if [ -n "$k8s_manifests" ]; then
+  gke_deploy_command="$gke_deploy_command -f $k8s_manifests"
 fi
 
 # Utilize Google APIs user agent for metrics with the following unique identifier:


### PR DESCRIPTION
<!--
Thank you for proposing a pull request! Please note that SOME TESTS WILL
LIKELY FAIL due to how GitHub exposes secrets in Pull Requests from forks.
Someone from the team will review your Pull Request and respond.

Please describe your change and any implementation details below.
-->
I added optional input `k8s_manifests` to be passed to the binary `gke-deploy` subroutine `run` as parameter `-f`. It enables this GitHub Action users to use other than suggested configs within the target k8s cluster.